### PR TITLE
Reorganize code layout in preparation for background cache updates

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,12 +1,15 @@
 package cache
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/n3xem/gh-otui/github"
+	"github.com/n3xem/gh-otui/models"
 )
 
 func GetCachePath() string {
@@ -24,6 +27,96 @@ func LoadCache() ([]github.Repository, error) {
 		return nil, err
 	}
 	return repos, nil
+}
+
+func root() string {
+	return filepath.Join(os.Getenv("HOME"), ".config", "gh", "extensions", "gh-otui")
+}
+
+func hostPath(host string) string {
+	return filepath.Join(root(), host)
+}
+
+func path(host, org string) string {
+	return filepath.Join(hostPath(host), org+".json")
+}
+
+func FetchRepositories(ctx context.Context) ([]*models.RepositoryGroup, error) {
+	dirs, err := os.ReadDir(root())
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cache directory: %w", err)
+	}
+
+	groups := make([]*models.RepositoryGroup, 0, len(dirs))
+	for _, dir := range dirs {
+		files, err := os.ReadDir(filepath.Join(root(), dir.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read cache directory: %w", err)
+		}
+		for _, file := range files {
+			host := dir.Name()
+			org := strings.TrimSuffix(file.Name(), ".json")
+			repos, err := Load(ctx, host, org)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load cache for %s/%s: %w", host, org, err)
+			}
+			groups = append(groups, repos)
+		}
+	}
+	return groups, nil
+}
+
+type cacheDTO struct {
+	Repositories []models.Repository `json:"repositories"`
+}
+
+func Load(ctx context.Context, host, org string) (*models.RepositoryGroup, error) {
+	p := path(host, org)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+
+	var dto cacheDTO
+	if err := json.Unmarshal(b, &dto); err != nil {
+		return nil, err
+	}
+	repos := make([]models.Repository, 0, len(dto.Repositories))
+	for _, repo := range dto.Repositories {
+		repos = append(repos, models.Repository{
+			Name:    repo.Name,
+			OrgName: repo.OrgName,
+			Host:    repo.Host,
+			HtmlUrl: repo.HtmlUrl,
+		})
+	}
+	g, err := models.NewRepositoryGroup(repos...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create repository group: %w", err)
+	}
+	return g, nil
+}
+
+func Save(ctx context.Context, g *models.RepositoryGroup) error {
+	repos := g.Repositories()
+	dto := cacheDTO{
+		Repositories: repos,
+	}
+	b, err := json.Marshal(dto)
+	if err != nil {
+		return fmt.Errorf("failed to create cache: %w", err)
+	}
+
+	dir := hostPath(g.Host())
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	p := path(g.Host(), g.Organization())
+	if err := os.WriteFile(p, b, 0644); err != nil {
+		return fmt.Errorf("failed to save cache: %w", err)
+	}
+	return nil
 }
 
 func SaveCache(repos []github.Repository) error {

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -49,6 +49,9 @@ func FetchRepositories(ctx context.Context) ([]*models.RepositoryGroup, error) {
 
 	groups := make([]*models.RepositoryGroup, 0, len(dirs))
 	for _, dir := range dirs {
+		if !dir.IsDir() {
+			continue
+		}
 		files, err := os.ReadDir(filepath.Join(root(), dir.Name()))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read cache directory: %w", err)

--- a/github/client.go
+++ b/github/client.go
@@ -1,13 +1,17 @@
 package github
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"iter"
+	"maps"
 	"net/url"
 	"strconv"
 	"strings"
 
 	"github.com/cli/go-gh/v2/pkg/api"
+	"github.com/n3xem/gh-otui/models"
 )
 
 type Organization struct {
@@ -26,6 +30,194 @@ type Client struct {
 	host   string
 }
 
+func (c *Client) fetchOrgRepositories(ctx context.Context, org string, page int) (repos []Repository, nextPage int, err error) {
+	var allRepos []Repository
+
+	resp, err := c.client.RequestWithContext(ctx, "GET", fmt.Sprintf("orgs/%s/repos?per_page=100&page=%d", org, page), nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to fetch organization repositories for %s: %w", org, err)
+	}
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&repos); err != nil {
+		return nil, 0, fmt.Errorf("failed to unmarshal organization repositories for %s: %w", org, err)
+	}
+
+	// Linkヘッダーの処理
+	linkHeader := resp.Header.Get("Link")
+	if linkHeader != "" {
+		links := strings.Split(linkHeader, ",")
+		for _, link := range links {
+			if strings.Contains(link, `rel="next"`) {
+				parts := strings.Split(link, ";")
+				urlPart := strings.Trim(parts[0], " <>")
+				parsedURL, err := url.Parse(urlPart)
+				if err != nil {
+					continue
+				}
+				query := parsedURL.Query()
+				if pageStr := query.Get("page"); pageStr != "" {
+					nextPage, err = strconv.Atoi(pageStr)
+					if err != nil {
+						continue
+					}
+				}
+			}
+		}
+	}
+
+	for i := range repos {
+		repos[i].OrgName = org
+		hostWithPath := strings.TrimPrefix(repos[i].HtmlUrl, "https://")
+		repos[i].Host = strings.Split(hostWithPath, "/")[0]
+	}
+	allRepos = append(allRepos, repos...)
+	return allRepos, nextPage, nil
+}
+
+func FetchCollaboratingRepositories(ctx context.Context, client *Client) (iter.Seq[*models.RepositoryGroup], error) {
+	page := 1
+	maxAttempts := 100
+	allRepos := make([]models.Repository, 0, 10000)
+	type key struct {
+		host string
+		org  string
+	}
+	groups := make(map[key]*models.RepositoryGroup)
+	for page > 0 && len(allRepos) < 10000 && maxAttempts > 0 {
+		repos, nextPage, err := client.fetchUserRepositories(ctx, affiliationCollaborator, page)
+		if err != nil {
+			return nil, err
+		}
+		for _, repo := range repos {
+			key := key{
+				host: repo.Host,
+				org:  repo.OrgName,
+			}
+			if group, ok := groups[key]; ok {
+				err := group.Add(models.Repository{
+					Name:    repo.Name,
+					OrgName: repo.OrgName,
+					Host:    repo.Host,
+					HtmlUrl: repo.HtmlUrl,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("failed to add repository to group: %w", err)
+				}
+			} else {
+				group, err := models.NewRepositoryGroup(models.Repository{
+					Name:    repo.Name,
+					OrgName: repo.OrgName,
+					Host:    repo.Host,
+					HtmlUrl: repo.HtmlUrl,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("failed to create repository group: %w", err)
+				}
+				groups[key] = group
+			}
+		}
+		page = nextPage
+		maxAttempts--
+	}
+	if maxAttempts == 0 {
+		return nil, fmt.Errorf("リポジトリの取得が上限に達しました")
+	}
+	return maps.Values(groups), nil
+}
+
+func FetchUserRepositories(ctx context.Context, client *Client) (*models.RepositoryGroup, error) {
+	page := 1
+	maxAttempts := 100
+	allRepos := make([]models.Repository, 0, 10000)
+	for page > 0 && len(allRepos) < 10000 && maxAttempts > 0 {
+		repos, nextPage, err := client.fetchUserRepositories(ctx, affiliationOwner, page)
+		if err != nil {
+			return nil, err
+		}
+		for _, repo := range repos {
+			allRepos = append(allRepos, models.Repository{
+				Name:    repo.Name,
+				OrgName: repo.OrgName,
+				Host:    repo.Host,
+				HtmlUrl: repo.HtmlUrl,
+			})
+		}
+		page = nextPage
+		maxAttempts--
+	}
+	if maxAttempts == 0 {
+		return nil, fmt.Errorf("リポジトリの取得が上限に達しました")
+	}
+	g, err := models.NewRepositoryGroup(allRepos...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create repository group: %w", err)
+	}
+	return g, nil
+}
+
+type OwnerOrganization struct {
+	name   string
+	client *Client
+}
+
+func NewOrganizations(ctx context.Context, client *Client) ([]*OwnerOrganization, error) {
+	gitOrgs, err := client.FetchOrganizations(ctx)
+	if err != nil {
+		return nil, err
+	}
+	organizations := make([]*OwnerOrganization, 0, len(gitOrgs))
+	for _, gitOrg := range gitOrgs {
+		org, err := NewOrganization(gitOrg.Login, client)
+		if err != nil {
+			return nil, err
+		}
+		organizations = append(organizations, org)
+	}
+	return organizations, nil
+}
+
+func NewOrganization(orgName string, client *Client) (*OwnerOrganization, error) {
+	if orgName == "" {
+		return nil, fmt.Errorf("organization name cannot be empty")
+	}
+	return &OwnerOrganization{
+		name:   orgName,
+		client: client,
+	}, nil
+}
+
+func (o *OwnerOrganization) FetchRepositories(ctx context.Context) (*models.RepositoryGroup, error) {
+	page := 1
+	maxAttempts := 100 // 安全のための最大ページ数
+	allRepos := make([]models.Repository, 0, 10000)
+
+	for page > 0 && len(allRepos) < 10000 && maxAttempts > 0 { // 追加の安全対策
+		repos, nextPage, err := o.client.fetchOrgRepositories(ctx, o.name, page)
+		if err != nil {
+			return nil, err
+		}
+		for _, repo := range repos {
+			allRepos = append(allRepos, models.Repository{
+				Name:    repo.Name,
+				OrgName: repo.OrgName,
+				Host:    repo.Host,
+				HtmlUrl: repo.HtmlUrl,
+			})
+		}
+		page = nextPage
+		maxAttempts--
+	}
+
+	if maxAttempts == 0 {
+		return nil, fmt.Errorf("リポジトリの取得が上限に達しました")
+	}
+	g, err := models.NewRepositoryGroup(allRepos...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create repository group: %w", err)
+	}
+	return g, nil
+}
+
 func NewClient(opts api.ClientOptions) (*Client, error) {
 	client, err := api.NewRESTClient(opts)
 	if err != nil {
@@ -35,63 +227,24 @@ func NewClient(opts api.ClientOptions) (*Client, error) {
 	return &Client{client: client, host: opts.Host}, nil
 }
 
-func (c *Client) FetchOrganizations() ([]Organization, error) {
+func (c *Client) FetchOrganizations(ctx context.Context) ([]Organization, error) {
 	var orgs []Organization
-	if err := c.client.Get("user/orgs", &orgs); err != nil {
+	if err := c.client.DoWithContext(ctx, "GET", "user/orgs", nil, &orgs); err != nil {
 		return nil, fmt.Errorf("failed to fetch organizations from %s: %w", c.host, err)
 	}
 	return orgs, nil
 }
 
-func (c *Client) FetchRepositories(orgs []Organization, page int) (repos []Repository, nextPage int, err error) {
-	var allRepos []Repository
+type affiliation string
 
-	for _, org := range orgs {
-		resp, err := c.client.Request("GET", fmt.Sprintf("orgs/%s/repos?per_page=100&page=%d", org.Login, page), nil)
-		if err != nil {
-			return nil, 0, fmt.Errorf("failed to fetch organization repositories for %s: %w", org.Login, err)
-		}
-		defer resp.Body.Close()
-		if err := json.NewDecoder(resp.Body).Decode(&repos); err != nil {
-			return nil, 0, fmt.Errorf("failed to unmarshal organization repositories for %s: %w", org.Login, err)
-		}
-
-		// Linkヘッダーの処理
-		linkHeader := resp.Header.Get("Link")
-		if linkHeader != "" {
-			links := strings.Split(linkHeader, ",")
-			for _, link := range links {
-				if strings.Contains(link, `rel="next"`) {
-					parts := strings.Split(link, ";")
-					urlPart := strings.Trim(parts[0], " <>")
-					parsedURL, err := url.Parse(urlPart)
-					if err != nil {
-						continue
-					}
-					query := parsedURL.Query()
-					if pageStr := query.Get("page"); pageStr != "" {
-						nextPage, err = strconv.Atoi(pageStr)
-						if err != nil {
-							continue
-						}
-					}
-				}
-			}
-		}
-
-		for i := range repos {
-			repos[i].OrgName = org.Login
-			hostWithPath := strings.TrimPrefix(repos[i].HtmlUrl, "https://")
-			repos[i].Host = strings.Split(hostWithPath, "/")[0]
-		}
-		allRepos = append(allRepos, repos...)
-	}
-	return allRepos, nextPage, nil
-}
+const (
+	affiliationOwner        affiliation = "owner"
+	affiliationCollaborator affiliation = "collaborator"
+)
 
 // fetch login user's repositories
-func (c *Client) FetchUserRepositories(page int) (repos []Repository, nextPage int, err error) {
-	resp, err := c.client.Request("GET", fmt.Sprintf("user/repos?per_page=100&page=%d", page), nil)
+func (c *Client) fetchUserRepositories(ctx context.Context, a affiliation, page int) (repos []Repository, nextPage int, err error) {
+	resp, err := c.client.RequestWithContext(ctx, "GET", fmt.Sprintf("user/repos?per_page=100&page=%d&affiliation=%s", page, a), nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to fetch user repositories: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
-	"strings"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/cli/go-gh/v2/pkg/api"
@@ -26,34 +29,6 @@ func checkCloneStatus(repos []models.Repository, ghqRoot string) []models.Reposi
 	return repos
 }
 
-func processSelectedRepository(repos []models.Repository, selected string, ghqRoot string) error {
-	for _, repo := range repos {
-		repoLine := repo.FormattedLine()
-		trimmedRepoLine := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(repoLine), "✓"))
-		trimmedSelected := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(selected), "✓"))
-
-		if trimmedRepoLine == trimmedSelected {
-			if !repo.Cloned {
-				s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
-				s.Suffix = fmt.Sprintf(" Cloning %s/%s...", repo.OrgName, repo.Name)
-				s.Start()
-				if err := cmd.CloneRepository(repo.GetGitURL()); err != nil {
-					s.Stop()
-					return err
-				}
-				s.Stop()
-			}
-			clonePath, err := repo.GetClonePath(ghqRoot)
-			if err != nil {
-				return fmt.Errorf("failed to get repository path: %w", err)
-			}
-			fmt.Println(clonePath)
-			return nil
-		}
-	}
-	return fmt.Errorf("repository not found")
-}
-
 func deduplicateRepositories(repos []models.Repository) []models.Repository {
 	seen := make(map[string]bool)
 	var result []models.Repository
@@ -69,161 +44,144 @@ func deduplicateRepositories(repos []models.Repository) []models.Repository {
 	return result
 }
 
-func main() {
+func run(ctx context.Context) error {
 	if err := cmd.CheckRequiredCommands(); err != nil {
-		fmt.Printf("Error: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 
-	ghqRoot, err := cmd.GetGhqRoot()
+	ghqRoot, err := cmd.GetGhqRoot(ctx)
 	if err != nil {
-		fmt.Printf("Failed to get ghq root: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to get ghq root: %w", err)
 	}
 
 	// Handle cache creation
 	if len(os.Args) > 1 && os.Args[1] == "--cache" {
 		s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+		s.Suffix = " Fetching repositories..."
+		s.Start()
 		hosts := auth.KnownHosts()
-		var allRepos []github.Repository
+		gihubClients := make([]*github.Client, 0, len(hosts))
 		for _, host := range hosts {
-			s.Suffix = fmt.Sprintf(" Connecting to %s...", host)
-			s.Start()
 			client, err := github.NewClient(api.ClientOptions{
 				Host: host,
 			})
 			if err != nil {
-				s.Stop()
-				fmt.Printf("Error: %v\n", err)
-				os.Exit(1)
+				return err
 			}
-			s.Stop()
-
-			// 自分のリポジトリを取得
-			s.Suffix = " Fetching user repositories..."
-			s.Start()
-			page := 1
-			maxAttempts := 100
-
-			for page > 0 && len(allRepos) < 10000 && maxAttempts > 0 {
-				repos, nextPage, err := client.FetchUserRepositories(page)
-				if err != nil {
-					s.Stop()
-					fmt.Printf("Error: %v\n", err)
-					os.Exit(1)
-				}
-				allRepos = append(allRepos, repos...)
-				page = nextPage
-				maxAttempts--
-			}
-			s.Stop()
-
-			s.Suffix = " Fetching organizations..."
-			s.Start()
-			orgs, err := client.FetchOrganizations()
-			if err != nil {
-				s.Stop()
-				fmt.Printf("Error: %v\n", err)
-				os.Exit(1)
-			}
-			s.Stop()
-
-			s.Suffix = " Fetching repositories..."
-			s.Start()
-			page = 1
-			maxAttempts = 100 // 安全のための最大ページ数
-
-			for page > 0 && len(allRepos) < 10000 && maxAttempts > 0 { // 追加の安全対策
-				repos, nextPage, err := client.FetchRepositories(orgs, page)
-				if err != nil {
-					s.Stop()
-					fmt.Printf("Error: %v\n", err)
-					os.Exit(1)
-				}
-				allRepos = append(allRepos, repos...)
-				page = nextPage
-				maxAttempts--
-			}
-
-			if maxAttempts == 0 {
-				s.Stop()
-				fmt.Printf("Error: リポジトリの取得が上限に達しました\n")
-				os.Exit(1)
-			}
-			s.Stop()
-
-			s.Suffix = " Saving cache..."
-			s.Start()
-			if err := cache.SaveCache(allRepos); err != nil {
-				s.Stop()
-				fmt.Printf("Error: %v\n", err)
-				os.Exit(1)
-			}
-			s.Stop()
+			gihubClients = append(gihubClients, client)
 		}
-		fmt.Println("Cache saved successfully")
-		return
+		bufErrors := make([]error, 0, 8)
+		for _, client := range gihubClients {
+			g, err := github.FetchUserRepositories(ctx, client)
+			if err != nil {
+				bufErrors = append(bufErrors, err)
+				continue
+			}
+			if err := cache.Save(ctx, g); err != nil {
+				bufErrors = append(bufErrors, err)
+				continue
+			}
+		}
+		for _, client := range gihubClients {
+			orgs, err := github.NewOrganizations(ctx, client)
+			if err != nil {
+				return err
+			}
+			for _, org := range orgs {
+				g, err := org.FetchRepositories(ctx)
+				if err != nil {
+					bufErrors = append(bufErrors, err)
+					continue
+				}
+				if err := cache.Save(ctx, g); err != nil {
+					bufErrors = append(bufErrors, err)
+					continue
+				}
+			}
+		}
+		for _, client := range gihubClients {
+			gs, err := github.FetchCollaboratingRepositories(ctx, client)
+			if err != nil {
+				bufErrors = append(bufErrors, err)
+				continue
+			}
+			for g := range gs {
+				if err := cache.Save(ctx, g); err != nil {
+					bufErrors = append(bufErrors, err)
+					continue
+				}
+			}
+		}
+		s.Stop()
+
+		if len(bufErrors) > 0 {
+			return errors.Join(bufErrors...)
+		}
+
+		fmt.Fprintln(os.Stderr, "Cache saved successfully")
+		return nil
 	}
+
+	allRepos := make([]models.Repository, 0)
 
 	// Load and process repositories
-	githubRepos, err := cache.LoadCache()
+	repositoryGroups, err := cache.FetchRepositories(ctx)
 	if err != nil {
-		fmt.Println("Cache not found. Please create cache with:")
-		fmt.Printf("%s --cache\n", os.Args[0])
-		os.Exit(1)
+		return fmt.Errorf("cache not found. Please create cache with: %s --cache", os.Args[0])
 	}
-
-	// Get all repositories in ghq root
-	ghqPaths, err := cmd.ListGhqRepositories()
-	if err != nil {
-		fmt.Printf("Failed to get ghq repositories: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Convert ghq paths directly to repositories
-	var allRepos []models.Repository
-	// Convert github.Repository to models.Repository
-	for _, repo := range githubRepos {
-		allRepos = append(allRepos, models.Repository{
-			Name:    repo.Name,
-			OrgName: repo.OrgName,
-			Host:    repo.Host,
-			HtmlUrl: repo.HtmlUrl,
-		})
+	for _, repos := range repositoryGroups {
+		allRepos = append(allRepos, repos.Repositories()...)
 	}
 
 	// Add local repositories from ghq
-	for _, ghqRepo := range ghqPaths {
-		repo, err := ghqRepo.ToRepository()
-		if err != nil {
-			continue // Skip invalid repository paths
-		}
-		allRepos = append(allRepos, repo)
+	ghqRepos, err := cmd.FetchGHQRepositories(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch ghq repositories: %w", err)
 	}
+	allRepos = append(allRepos, ghqRepos...)
 
 	// Remove duplicates
 	allRepos = deduplicateRepositories(allRepos)
 
 	allRepos = checkCloneStatus(allRepos, ghqRoot)
 
-	var lines []string
-	for _, repo := range allRepos {
-		lines = append(lines, repo.FormattedLine())
-	}
-
-	selected, err := cmd.RunSelector(lines)
+	selected, err := cmd.Select(ctx, allRepos)
 	if err != nil {
-		fmt.Printf("Failed to run selector: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error selecting repository: %w", err)
 	}
 
-	if selected == "" {
-		fmt.Println("No repository selected")
-		return
+	if !selected.Cloned {
+		s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+		s.Suffix = fmt.Sprintf(" Cloning %s/%s...", selected.OrgName, selected.Name)
+		s.Start()
+		if err := cmd.CloneRepository(ctx, selected.GetGitURL()); err != nil {
+			s.Stop()
+			return err
+		}
+		s.Stop()
+	}
+	clonePath, err := selected.GetClonePath(ghqRoot)
+	if err != nil {
+		return fmt.Errorf("failed to get repository path: %w", err)
 	}
 
-	if err := processSelectedRepository(allRepos, selected, ghqRoot); err != nil {
-		fmt.Printf("Error: %v\n", err)
+	fmt.Println(clonePath)
+	return nil
+}
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(),
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGHUP,
+	)
+	defer cancel()
+	if err := run(ctx); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		cancel()
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/models/repository.go
+++ b/models/repository.go
@@ -32,3 +32,51 @@ func (r Repository) FormattedLine() string {
 	}
 	return fmt.Sprintf("%s %s/%s/%s", cloneStatus, r.Host, r.OrgName, r.Name)
 }
+
+type RepositoryGroup struct {
+	host         string
+	organization string
+	repositories []Repository
+}
+
+func NewRepositoryGroup(repositories ...Repository) (*RepositoryGroup, error) {
+	if len(repositories) == 0 {
+		return nil, fmt.Errorf("no repositories provided")
+	}
+
+	g := &RepositoryGroup{
+		host:         repositories[0].Host,
+		organization: repositories[0].OrgName,
+		repositories: make([]Repository, 0, len(repositories)),
+	}
+
+	for _, repo := range repositories {
+		if err := g.Add(repo); err != nil {
+			return nil, err
+		}
+	}
+	return g, nil
+}
+
+func (g *RepositoryGroup) Host() string {
+	return g.host
+}
+
+func (g *RepositoryGroup) Organization() string {
+	return g.organization
+}
+
+func (g *RepositoryGroup) Add(repo Repository) error {
+	if repo.Host != g.host {
+		return fmt.Errorf("repository host %s does not match group host %s", repo.Host, g.host)
+	}
+	if repo.OrgName != g.organization {
+		return fmt.Errorf("repository organization %s does not match group organization %s", repo.OrgName, g.organization)
+	}
+	g.repositories = append(g.repositories, repo)
+	return nil
+}
+
+func (g *RepositoryGroup) Repositories() []Repository {
+	return g.repositories
+}


### PR DESCRIPTION
This PR reorganizes the internal code structure to make future improvements—such as background cache updates and concurrent processing—easier to implement.

As part of this refactoring, the cache file structure has been updated to better isolate data per organization and host.

Changed cache file layout:

Before:
~/.config/gh/extensions/gh-otui/cache.json


After:
~/.config/gh/extensions/gh-otui/\<host\>/\<org\>.json
e.g. ~/.config/gh/extensions/gh-otui/github.com/qawatake.json