### PR TITLE
Fetch repositories under the same owner concurrently

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/n3xem/gh-otui/models"
+	"github.com/sourcegraph/conc/pool"
 )
 
 type Organization struct {
@@ -25,44 +26,39 @@ type Repository struct {
 	Host    string
 }
 
+func (r Repository) ToDomain() models.Repository {
+	return models.Repository{
+		Name:    r.Name,
+		OrgName: r.OrgName,
+		Host:    r.Host,
+		HtmlUrl: r.HtmlUrl,
+	}
+}
+
 type Client struct {
 	client *api.RESTClient
 	host   string
 }
 
-func (c *Client) fetchOrgRepositories(ctx context.Context, org string, page int) (repos []Repository, nextPage int, err error) {
-	var allRepos []Repository
-
+func (c *Client) fetchOrgRepositories(ctx context.Context, org string, page int) (repos []Repository, nextPage int, lastPage int, err error) {
 	resp, err := c.client.RequestWithContext(ctx, "GET", fmt.Sprintf("orgs/%s/repos?per_page=100&page=%d", org, page), nil)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to fetch organization repositories for %s: %w", org, err)
+		return nil, 0, 0, fmt.Errorf("failed to fetch organization repositories for %s: %w", org, err)
 	}
 	defer resp.Body.Close()
 	if err := json.NewDecoder(resp.Body).Decode(&repos); err != nil {
-		return nil, 0, fmt.Errorf("failed to unmarshal organization repositories for %s: %w", org, err)
+		return nil, 0, 0, fmt.Errorf("failed to unmarshal organization repositories for %s: %w", org, err)
 	}
 
 	// Linkヘッダーの処理
 	linkHeader := resp.Header.Get("Link")
 	if linkHeader != "" {
-		links := strings.Split(linkHeader, ",")
-		for _, link := range links {
-			if strings.Contains(link, `rel="next"`) {
-				parts := strings.Split(link, ";")
-				urlPart := strings.Trim(parts[0], " <>")
-				parsedURL, err := url.Parse(urlPart)
-				if err != nil {
-					continue
-				}
-				query := parsedURL.Query()
-				if pageStr := query.Get("page"); pageStr != "" {
-					nextPage, err = strconv.Atoi(pageStr)
-					if err != nil {
-						continue
-					}
-				}
-			}
+		next, last, err := parseLinkHeader(linkHeader)
+		if err != nil {
+			return nil, 0, 0, fmt.Errorf("failed to parse link header: %w", err)
 		}
+		nextPage = next
+		lastPage = last
 	}
 
 	for i := range repos {
@@ -70,89 +66,153 @@ func (c *Client) fetchOrgRepositories(ctx context.Context, org string, page int)
 		hostWithPath := strings.TrimPrefix(repos[i].HtmlUrl, "https://")
 		repos[i].Host = strings.Split(hostWithPath, "/")[0]
 	}
-	allRepos = append(allRepos, repos...)
-	return allRepos, nextPage, nil
+	return repos, nextPage, lastPage, nil
+}
+
+func parseLinkHeader(linkHeader string) (nextPage, lastPage int, err error) {
+	links := strings.Split(linkHeader, ",")
+	for _, link := range links {
+		if strings.Contains(link, `rel="next"`) {
+			parts := strings.Split(link, ";")
+			urlPart := strings.Trim(parts[0], " <>")
+			parsedURL, err := url.Parse(urlPart)
+			if err != nil {
+				return 0, 0, err
+			}
+			query := parsedURL.Query()
+			if pageStr := query.Get("page"); pageStr != "" {
+				nextPage, err = strconv.Atoi(pageStr)
+				if err != nil {
+					return 0, 0, err
+				}
+			}
+		} else if strings.Contains(link, `rel="last"`) {
+			parts := strings.Split(link, ";")
+			urlPart := strings.Trim(parts[0], " <>")
+			parsedURL, err := url.Parse(urlPart)
+			if err != nil {
+				return 0, 0, err
+			}
+			query := parsedURL.Query()
+			if pageStr := query.Get("page"); pageStr != "" {
+				lastPage, err = strconv.Atoi(pageStr)
+				if err != nil {
+					return 0, 0, err
+				}
+			}
+		}
+	}
+	return nextPage, lastPage, nil
 }
 
 func FetchCollaboratingRepositories(ctx context.Context, client *Client) (iter.Seq[*models.RepositoryGroup], error) {
-	page := 1
-	maxAttempts := 100
-	allRepos := make([]models.Repository, 0, 10000)
 	type key struct {
 		host string
 		org  string
 	}
 	groups := make(map[key]*models.RepositoryGroup)
-	for page > 0 && len(allRepos) < 10000 && maxAttempts > 0 {
-		repos, nextPage, err := client.fetchUserRepositories(ctx, affiliationCollaborator, page)
-		if err != nil {
-			return nil, err
-		}
-		for _, repo := range repos {
-			key := key{
-				host: repo.Host,
-				org:  repo.OrgName,
-			}
-			if group, ok := groups[key]; ok {
-				err := group.Add(models.Repository{
-					Name:    repo.Name,
-					OrgName: repo.OrgName,
-					Host:    repo.Host,
-					HtmlUrl: repo.HtmlUrl,
-				})
-				if err != nil {
-					return nil, fmt.Errorf("failed to add repository to group: %w", err)
-				}
-			} else {
-				group, err := models.NewRepositoryGroup(models.Repository{
-					Name:    repo.Name,
-					OrgName: repo.OrgName,
-					Host:    repo.Host,
-					HtmlUrl: repo.HtmlUrl,
-				})
-				if err != nil {
-					return nil, fmt.Errorf("failed to create repository group: %w", err)
-				}
-				groups[key] = group
-			}
-		}
-		page = nextPage
-		maxAttempts--
+	ghRepos, err := fetchCollaboratingRepositories(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch collaborating repositories: %w", err)
 	}
-	if maxAttempts == 0 {
-		return nil, fmt.Errorf("リポジトリの取得が上限に達しました")
+	repos := mapValues(ghRepos, Repository.ToDomain)
+	for _, repo := range repos {
+		key := key{
+			host: repo.Host,
+			org:  repo.OrgName,
+		}
+		if group, ok := groups[key]; ok {
+			err := group.Add(repo)
+			if err != nil {
+				return nil, fmt.Errorf("failed to add repository to group: %w", err)
+			}
+		} else {
+			group, err := models.NewRepositoryGroup(repo)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create repository group: %w", err)
+			}
+			groups[key] = group
+		}
 	}
 	return maps.Values(groups), nil
 }
 
-func FetchUserRepositories(ctx context.Context, client *Client) (*models.RepositoryGroup, error) {
-	page := 1
+func fetchCollaboratingRepositories(ctx context.Context, client *Client) ([]Repository, error) {
 	maxAttempts := 100
-	allRepos := make([]models.Repository, 0, 10000)
-	for page > 0 && len(allRepos) < 10000 && maxAttempts > 0 {
-		repos, nextPage, err := client.fetchUserRepositories(ctx, affiliationOwner, page)
-		if err != nil {
-			return nil, err
-		}
-		for _, repo := range repos {
-			allRepos = append(allRepos, models.Repository{
-				Name:    repo.Name,
-				OrgName: repo.OrgName,
-				Host:    repo.Host,
-				HtmlUrl: repo.HtmlUrl,
-			})
-		}
-		page = nextPage
-		maxAttempts--
+	allRepos := make([]Repository, 0, 10000)
+	repos, nextPage, lastPage, err := client.fetchUserRepositories(ctx, affiliationCollaborator, 1)
+	if err != nil {
+		return nil, err
 	}
-	if maxAttempts == 0 {
-		return nil, fmt.Errorf("リポジトリの取得が上限に達しました")
+	allRepos = append(allRepos, repos...)
+	if lastPage == 0 || lastPage == 1 {
+		return allRepos, nil
 	}
-	g, err := models.NewRepositoryGroup(allRepos...)
+	lastPage = min(lastPage, maxAttempts)
+	p := pool.NewWithResults[[]Repository]().WithContext(ctx).WithMaxGoroutines(5)
+	for page := nextPage; page <= lastPage; page++ {
+		p.Go(func(ctx context.Context) ([]Repository, error) {
+			repos, _, _, err := client.fetchUserRepositories(ctx, affiliationCollaborator, page)
+			if err != nil {
+				return nil, err
+			}
+			return repos, nil
+		})
+	}
+	repoLists, err := p.Wait()
+	if err != nil {
+		return nil, err
+	}
+	allRepos = append(allRepos, flatten(repoLists)...)
+	return allRepos, nil
+}
+
+func FetchUserRepositories(ctx context.Context, client *Client) (*models.RepositoryGroup, error) {
+	ghRepos, err := fetchUserRepositories(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch repositories for user: %w", err)
+	}
+
+	repos := mapValues(ghRepos, Repository.ToDomain)
+
+	g, err := models.NewRepositoryGroup(repos...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repository group: %w", err)
 	}
 	return g, nil
+}
+
+func fetchUserRepositories(ctx context.Context, client *Client) ([]Repository, error) {
+	maxAttempts := 100
+	allRepos := make([]Repository, 0, 10000)
+
+	repos, nextPage, lastPage, err := client.fetchUserRepositories(ctx, affiliationOwner, 1)
+	if err != nil {
+		return nil, err
+	}
+	allRepos = append(allRepos, repos...)
+	if lastPage == 0 || lastPage == 1 {
+		return repos, nil
+	}
+	lastPage = min(lastPage, maxAttempts)
+
+	p := pool.NewWithResults[[]Repository]().WithContext(ctx).WithMaxGoroutines(5)
+	for page := nextPage; page <= lastPage; page++ {
+		p.Go(func(ctx context.Context) ([]Repository, error) {
+			repos, _, _, err := client.fetchUserRepositories(ctx, affiliationOwner, page)
+			if err != nil {
+				return nil, err
+			}
+			return repos, nil
+		})
+	}
+
+	repoLists, err := p.Wait()
+	if err != nil {
+		return nil, err
+	}
+	allRepos = append(allRepos, flatten(repoLists)...)
+	return allRepos, nil
 }
 
 type OwnerOrganization struct {
@@ -186,32 +246,68 @@ func NewOrganization(orgName string, client *Client) (*OwnerOrganization, error)
 	}, nil
 }
 
-func (o *OwnerOrganization) FetchRepositories(ctx context.Context) (*models.RepositoryGroup, error) {
-	page := 1
+func (o *OwnerOrganization) fetchRepositories(ctx context.Context) ([]Repository, error) {
 	maxAttempts := 100 // 安全のための最大ページ数
-	allRepos := make([]models.Repository, 0, 10000)
+	allRepos := make([]Repository, 0, 10000)
 
-	for page > 0 && len(allRepos) < 10000 && maxAttempts > 0 { // 追加の安全対策
-		repos, nextPage, err := o.client.fetchOrgRepositories(ctx, o.name, page)
-		if err != nil {
-			return nil, err
-		}
-		for _, repo := range repos {
-			allRepos = append(allRepos, models.Repository{
-				Name:    repo.Name,
-				OrgName: repo.OrgName,
-				Host:    repo.Host,
-				HtmlUrl: repo.HtmlUrl,
-			})
-		}
-		page = nextPage
-		maxAttempts--
+	repos, nextPage, lastPage, err := o.client.fetchOrgRepositories(ctx, o.name, 1)
+	if err != nil {
+		return nil, err
+	}
+	allRepos = append(allRepos, repos...)
+	if lastPage == 0 || lastPage == 1 {
+		return allRepos, nil
+	}
+	lastPage = min(lastPage, maxAttempts)
+
+	p := pool.NewWithResults[[]Repository]().WithContext(ctx).WithMaxGoroutines(5)
+	for page := nextPage; page <= lastPage; page++ {
+		p.Go(func(ctx context.Context) ([]Repository, error) {
+			repos, _, _, err := o.client.fetchOrgRepositories(ctx, o.name, page)
+			if err != nil {
+				return nil, err
+			}
+			return repos, nil
+		})
 	}
 
-	if maxAttempts == 0 {
-		return nil, fmt.Errorf("リポジトリの取得が上限に達しました")
+	repoLists, err := p.Wait()
+	if err != nil {
+		return nil, err
 	}
-	g, err := models.NewRepositoryGroup(allRepos...)
+	allRepos = append(allRepos, flatten(repoLists)...)
+	return allRepos, nil
+}
+
+func flatten[T any](slices [][]T) []T {
+	length := 0
+	for _, slice := range slices {
+		length += len(slice)
+	}
+	results := make([]T, 0, length)
+	for _, slice := range slices {
+		results = append(results, slice...)
+	}
+	return results
+}
+
+func mapValues[U any, S ~[]U, V any](values S, f func(U) V) []V {
+	results := make([]V, 0, len(values))
+	for _, value := range values {
+		results = append(results, f(value))
+	}
+	return results
+}
+
+func (o *OwnerOrganization) FetchRepositories(ctx context.Context) (*models.RepositoryGroup, error) {
+	ghRepos, err := o.fetchRepositories(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch repositories for organization %s: %w", o.name, err)
+	}
+
+	repos := mapValues(ghRepos, Repository.ToDomain)
+
+	g, err := models.NewRepositoryGroup(repos...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repository group: %w", err)
 	}
@@ -243,38 +339,26 @@ const (
 )
 
 // fetch login user's repositories
-func (c *Client) fetchUserRepositories(ctx context.Context, a affiliation, page int) (repos []Repository, nextPage int, err error) {
+func (c *Client) fetchUserRepositories(ctx context.Context, a affiliation, page int) (repos []Repository, nextPage int, lastPage int, err error) {
 	resp, err := c.client.RequestWithContext(ctx, "GET", fmt.Sprintf("user/repos?per_page=100&page=%d&affiliation=%s", page, a), nil)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to fetch user repositories: %w", err)
+		return nil, 0, 0, fmt.Errorf("failed to fetch user repositories: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if err := json.NewDecoder(resp.Body).Decode(&repos); err != nil {
-		return nil, 0, fmt.Errorf("failed to unmarshal user repositories: %w", err)
+		return nil, 0, 0, fmt.Errorf("failed to unmarshal user repositories: %w", err)
 	}
 
 	// Linkヘッダーの処理
 	linkHeader := resp.Header.Get("Link")
 	if linkHeader != "" {
-		links := strings.Split(linkHeader, ",")
-		for _, link := range links {
-			if strings.Contains(link, `rel="next"`) {
-				parts := strings.Split(link, ";")
-				urlPart := strings.Trim(parts[0], " <>")
-				parsedURL, err := url.Parse(urlPart)
-				if err != nil {
-					continue
-				}
-				query := parsedURL.Query()
-				if pageStr := query.Get("page"); pageStr != "" {
-					nextPage, err = strconv.Atoi(pageStr)
-					if err != nil {
-						continue
-					}
-				}
-			}
+		next, last, err := parseLinkHeader(linkHeader)
+		if err != nil {
+			return nil, 0, 0, fmt.Errorf("failed to parse link header: %w", err)
 		}
+		nextPage = next
+		lastPage = last
 	}
 
 	// リポジトリ情報の補完
@@ -285,5 +369,5 @@ func (c *Client) fetchUserRepositories(ctx context.Context, a affiliation, page 
 		repos[i].OrgName = strings.Split(strings.TrimPrefix(repos[i].HtmlUrl, "https://"+repos[i].Host+"/"), "/")[0]
 	}
 
-	return repos, nextPage, nil
+	return repos, nextPage, lastPage, nil
 }

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func updateCache(ctx context.Context) (updated bool, err error) {
 		}
 		gihubClients = append(gihubClients, client)
 	}
-	p := pool.NewWithResults[[]*models.RepositoryGroup]().WithErrors().WithContext(ctx)
+	p := pool.NewWithResults[[]*models.RepositoryGroup]().WithErrors().WithContext(ctx).WithMaxGoroutines(5)
 	// 自分のリポジトリを取得
 	p.Go(func(ctx context.Context) ([]*models.RepositoryGroup, error) {
 		gp := pool.NewWithResults[*models.RepositoryGroup]().WithErrors().WithContext(ctx)
@@ -125,7 +125,7 @@ func updateCache(ctx context.Context) (updated bool, err error) {
 		return g != nil
 	})
 	if !someCached {
-		return false, nil
+		return false, err
 	}
 	e := cache.Done(ctx)
 	err = errors.Join(err, e)


### PR DESCRIPTION
Previously, repositories belonging to the same owner were fetched sequentially, which caused significant delays for organizations with a large number of repositories.
This change allows those repositories to be fetched concurrently, improving performance.

Observed improvement with an organization that has around 1200 repositories:

```sh
# Before:
gh otui  0.48s user 0.23s system 1% cpu 43.846 total

# After:
gh otui  0.40s user 0.11s system 3% cpu 14.222 total
```